### PR TITLE
Link download buttons via script

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,7 @@
+const DOWNLOAD_URL = 'https://github.com/Dojo4education/Dojo4education-site/releases/download/01.25052025/ThesisAudit.exe';
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.download-btn').forEach(el => {
+    el.href = DOWNLOAD_URL;
+  });
+});

--- a/thesisaudit.html
+++ b/thesisaudit.html
@@ -44,7 +44,7 @@
       Кредиты активны <b>1 месяц</b>, затем замораживаются до следующего доната.
     </p>
 
-    <a href="https://github.com/Dojo4education/Dojo4education-site/releases/download/01.25052025/ThesisAudit.exe" class="button" style="margin: 24px auto 16px auto;" target="_blank" rel="noopener noreferrer">
+    <a class="button download-btn" style="margin: 24px auto 16px auto;" target="_blank" rel="noopener noreferrer">
       <svg viewBox="0 0 448 512"><path d="M0 93.7v157.4l204.8-28.3V65.4L0 93.7zM224 61.7v162.5l224-31V32L224 61.7zM0 260.9v157.4l204.8 28.3V289.2L0 260.9zM224 288.3v162.5l224 31V320l-224-31.7z"/></svg>
       Скачать для Windows
     </a>
@@ -52,6 +52,7 @@
     <div class="footer">
       © 2025 Dojo4Education
     </div>
+    <script src="script.js"></script>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move ThesisAudit download URL into script.js
- set download button hrefs on DOMContentLoaded
- load script.js from ThesisAudit page

## Testing
- `git status --short`

